### PR TITLE
Fix checkbox / switch fields invalid state

### DIFF
--- a/templates/form/default.html.twig
+++ b/templates/form/default.html.twig
@@ -152,7 +152,7 @@
 {%- block checkbox_radio_label -%}
     {#- Do not display the label if widget is not defined in order to prevent double label rendering -#}
     {%- if widget is defined -%}
-        {%- if checked and form.parent.vars.valid == false -%}
+        {%- if checked and form.vars.valid == false -%}
             {%- set valid = false -%}
         {%- endif -%}
         {%- set label_attr_class = (valid ? block('class_input_radio_label') : block('class_input_radio_label_error')) ~ ' ' ~ label_attr.class|default('') -%}
@@ -182,7 +182,7 @@
 {% block switch_label -%}
     {#- Do not display the label if widget is not defined in order to prevent double label rendering -#}
     {%- if widget is defined -%}
-        {%- if checked and form.parent.vars.valid == false -%}
+        {%- if checked and form.vars.valid == false -%}
             {%- set valid = false -%}
         {%- endif -%}
         {%- set label_attr_class = (valid ? block('class_input_switch_label') : block('class_input_switch_label_error')) ~ ' ' ~ label_attr.class|default('') -%}


### PR DESCRIPTION
In the custom form theme block `checkbox_radio_label`, the field validity is incorrectly determined using `form.parent.vars.valid`. This checks the validity of the *entire parent form*, not the individual field.

Fix #31 

### ❌ **Current behavior**

```twig
{% if checked and form.parent.vars.valid == false %}
    {% set valid = false %}
{% endif %}
```

Even if the current field has no validation error, it is marked as invalid if *any* other field in the parent form is invalid.

### ✅ **Expected behavior**

The validity check should be scoped to the current field only.

### 🛠️ **Impact**

This causes incorrect error styling on checkbox or radio labels, even when they are valid, as soon as any unrelated form field fails validation.

