### PR TITLE
bump tales-from-a-dev/twig-tailwind-extra to 0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "php": ">=8.1",
     "symfony/http-kernel": "^6.4 || ^7.0",
     "symfony/twig-bridge": "^6.4 || ^7.0",
-    "tales-from-a-dev/twig-tailwind-extra": "^0.4"
+    "tales-from-a-dev/twig-tailwind-extra": "^0.5"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.15",


### PR DESCRIPTION
it should be safe to merge as the `tailwind_merge` has no usage in this project with the `configuration` argument

https://github.com/tales-from-a-dev/twig-tailwind-extra/releases/tag/v0.5.0